### PR TITLE
Zero alloc NoMetrics

### DIFF
--- a/src/Ubiquitous.Metrics.Dogstatsd/StatsdCount.cs
+++ b/src/Ubiquitous.Metrics.Dogstatsd/StatsdCount.cs
@@ -1,8 +1,24 @@
+using System;
 using StatsdClient;
 
 namespace Ubiquitous.Metrics.Dogstatsd {
     class StatsdCount : StatsdMetric, ICountMetric {
         internal StatsdCount(MetricDefinition metricDefinition) : base(metricDefinition) => _base = new BaseCount();
+
+        public void Inc()
+        {
+            Inc(1, Array.Empty<string>());
+        }
+
+        public void Inc(string label)
+        {
+            Inc(1, new[] {label});
+        }
+
+        public void Inc(int count, string label)
+        {
+            Inc(count,  new[] {label});
+        }
 
         public void Inc(int count = 1, params string[] labels) {
             DogStatsd.Increment(MetricName, count, tags: FormTags(labels));

--- a/src/Ubiquitous.Metrics.MicrosoftLog/LogCount.cs
+++ b/src/Ubiquitous.Metrics.MicrosoftLog/LogCount.cs
@@ -1,9 +1,25 @@
+using System;
 using Microsoft.Extensions.Logging;
 
 namespace Ubiquitous.Metrics.MicrosoftLog {
     class LogCount : LoggingMetric, ICountMetric {
         internal LogCount(MetricDefinition metricDefinition, ILogger log) : base(metricDefinition, log) { }
 
+        public void Inc()
+        {
+            Inc(1, Array.Empty<string>());
+        }
+
+        public void Inc(string label)
+        {
+            Inc(1, new[] {label});
+        }
+
+        public void Inc(int count, string label)
+        {
+            Inc(count,  new[] {label});
+        }
+        
         public void Inc(int count = 1, params string[] labels) {
             Count += count;
 

--- a/src/Ubiquitous.Metrics.Prometheus/PrometheusCount.cs
+++ b/src/Ubiquitous.Metrics.Prometheus/PrometheusCount.cs
@@ -1,3 +1,4 @@
+using System;
 using Prometheus;
 using Ubiquitous.Metrics.Labels;
 
@@ -16,6 +17,21 @@ namespace Ubiquitous.Metrics.Prometheus {
                 }
             );
             _base = new BaseCount();
+        }
+        
+        public void Inc()
+        {
+            Inc(1, Array.Empty<string>());
+        }
+
+        public void Inc(string label)
+        {
+            Inc(1, new[] {label});
+        }
+
+        public void Inc(int count, string label)
+        {
+            Inc(count,  new[] {label});
         }
 
         public void Inc(int count = 1, params string[]? labels) {

--- a/src/Ubiquitous.Metrics/Combined/CombinedCount.cs
+++ b/src/Ubiquitous.Metrics/Combined/CombinedCount.cs
@@ -8,6 +8,21 @@ namespace Ubiquitous.Metrics.Combined {
 
         internal CombinedCount(ICollection<ICountMetric> inner) => _inner = inner;
 
+        public void Inc()
+        {
+            _inner.ForEach(x => x.Inc(1));
+        }
+
+        public void Inc(string label)
+        {
+            _inner.ForEach(x => x.Inc(1, label));
+        }
+
+        public void Inc(int count, string label)
+        {
+            _inner.ForEach(x => x.Inc(count, label));
+        }
+
         public void Inc(int count = 1, params string[] labels) {
             _inner.ForEach(x => x.Inc(count, labels));
         }

--- a/src/Ubiquitous.Metrics/ICountMetric.cs
+++ b/src/Ubiquitous.Metrics/ICountMetric.cs
@@ -3,13 +3,19 @@ namespace Ubiquitous.Metrics {
     /// Counter metric, which only can increase
     /// </summary>
     public interface ICountMetric {
+        
+        //Zero Alloc overloads
+        void Inc();
+        void Inc(string label);
+        void Inc(int count, string label);
+        
         /// <summary>
         /// Increase the counter by a given number
         /// </summary>
         /// <param name="count">Optional: increase count, one by default</param>
         /// <param name="labels">Optional: metric labels, must be matching the number of configured label names</param>
         void Inc(int count = 1, params string[] labels);
-        
+
         /// <summary>
         /// Currently observed count
         /// </summary>

--- a/src/Ubiquitous.Metrics/NoMetricsProvider.cs
+++ b/src/Ubiquitous.Metrics/NoMetricsProvider.cs
@@ -26,6 +26,21 @@ namespace Ubiquitous.Metrics {
 
             protected internal NoCount(MetricDefinition definition) : base(definition) { }
 
+            public void Inc()
+            {
+            //    Interlocked.Add(ref _count, 1);
+            }
+
+            public void Inc(string label)
+            {
+            //    Interlocked.Add(ref _count, 1);
+            }
+
+            public void Inc(int count, string label)
+            {
+            //    Interlocked.Add(ref _count, count);
+            }
+
             public void Inc(int count = 1, params string[]? labels) => Interlocked.Add(ref _count, count);
             public long Count => _count;
         }


### PR DESCRIPTION
WIP

The current implementation relies on params string[], which forces allocations of a string array in every call.
Adding some standard overloads makes it possible to avoid this allocation.
This is especially important for a real no-op provider, to avoid allocations in hot-paths, e.g. Proto.Actor Receive pipeline.

Not pretty, but it works.