### PR TITLE
parameterless StatsdConfigurator constructor

### DIFF
--- a/src/Ubiquitous.Metrics.Dogstatsd/StatsdConfigurator.cs
+++ b/src/Ubiquitous.Metrics.Dogstatsd/StatsdConfigurator.cs
@@ -25,6 +25,11 @@ namespace Ubiquitous.Metrics.Dogstatsd {
                 }
             );
 
+        /// <summary>
+        /// Should be used if DogStatsd is already configured.
+        /// </summary>
+        public StatsdConfigurator() { }
+
         public ICountMetric CreateCount(MetricDefinition metricDefinition) => new StatsdCount(metricDefinition);
 
         public IHistogramMetric CreateHistogram(MetricDefinition metricDefinition) => new StatsdHistogram(metricDefinition);


### PR DESCRIPTION
Services that already are using DogStatsD in some other places don't require configuring it again. A parameterless constructor for statsdconfigurator gives the opportunity to not configure it again.