### PR TITLE
Fix double invocation of action

### DIFF
--- a/src/Ubiquitous.Metrics/Metrics.cs
+++ b/src/Ubiquitous.Metrics/Metrics.cs
@@ -161,7 +161,7 @@ namespace Ubiquitous.Metrics {
 
             try {
                 var task = action();
-                result = task.IsCompleted ? task.Result : await action();
+                result = task.IsCompleted ? task.Result : await task;
             }
             catch (Exception) {
                 errorCount?.Inc(labels);
@@ -199,7 +199,7 @@ namespace Ubiquitous.Metrics {
 
             try {
                 var task = action();
-                result = task.IsCompleted ? task.Result : await action();
+                result = task.IsCompleted ? task.Result : await task;
             }
             catch (Exception) {
                 errorCount?.Inc(labels: labels);
@@ -238,7 +238,7 @@ namespace Ubiquitous.Metrics {
 
             try {
                 var task = action();
-                result = task.IsCompleted ? task.Result : await action();
+                result = task.IsCompleted ? task.Result : await task;
             }
             catch (Exception) {
                 errorCount?.Inc(labels);


### PR DESCRIPTION
Currently, the Measure method incorrectly invokes the `action` in case it returned a non completed task during the first invocation.

TLDR; the measure methods calls the action twice.