### PR TITLE
Allow Metrics instance to run without any configuration

### DIFF
--- a/Ubiquitous.Metrics.sln
+++ b/Ubiquitous.Metrics.sln
@@ -16,6 +16,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{FCC6B170
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ubiquitous.Metrics.DogstatsdTests", "test\Ubiquitous.Metrics.DogstatsdTests\Ubiquitous.Metrics.DogstatsdTests.csproj", "{0B906251-A1F8-483C-B38B-CEF42542F4D5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ubiquitous.Metrics.Tests", "test\Ubiquitous.Metrics.Tests\Ubiquitous.Metrics.Tests.csproj", "{11674751-77D7-4267-8BF3-F626CD563100}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -46,11 +48,16 @@ Global
 		{0B906251-A1F8-483C-B38B-CEF42542F4D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0B906251-A1F8-483C-B38B-CEF42542F4D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0B906251-A1F8-483C-B38B-CEF42542F4D5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{11674751-77D7-4267-8BF3-F626CD563100}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11674751-77D7-4267-8BF3-F626CD563100}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11674751-77D7-4267-8BF3-F626CD563100}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11674751-77D7-4267-8BF3-F626CD563100}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{ADEF7CBE-D1CB-45BB-A105-B7E27A7A9B76} = {9D8B5837-914A-4683-A7AA-18E05EEAA8CD}
 		{DB2E241F-E447-406B-AE16-1D908FE0CDEC} = {9D8B5837-914A-4683-A7AA-18E05EEAA8CD}
 		{127825BC-ACCB-488C-9821-AF539474E627} = {9D8B5837-914A-4683-A7AA-18E05EEAA8CD}
 		{0B906251-A1F8-483C-B38B-CEF42542F4D5} = {FCC6B170-077B-456D-9D82-5C9FE0F43B05}
+		{11674751-77D7-4267-8BF3-F626CD563100} = {FCC6B170-077B-456D-9D82-5C9FE0F43B05}
 	EndGlobalSection
 EndGlobal

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -29,11 +29,12 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="MinVer" Version="2.4.0">
+    <PackageReference Include="MinVer" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="JetBrains.Annotations" Version="2020.3.0" PrivateAssets="All" />
+    <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
 
 </Project>

--- a/src/Ubiquitous.Metrics.Diagnostics/Ubiquitous.Metrics.Diagnostics.csproj
+++ b/src/Ubiquitous.Metrics.Diagnostics/Ubiquitous.Metrics.Diagnostics.csproj
@@ -4,7 +4,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="3.1.8"/>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="3.1.18" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
     </ItemGroup>
 </Project>

--- a/src/Ubiquitous.Metrics/Metrics.cs
+++ b/src/Ubiquitous.Metrics/Metrics.cs
@@ -56,7 +56,7 @@ namespace Ubiquitous.Metrics {
         /// <param name="definition">Metric definition (name, description and labels)</param>
         /// <returns></returns>
         public ICountMetric CreateCount(MetricDefinition definition)
-            => Ensure.NotDefault(_createCount, "Metrics provider hasn't been configured")(definition);
+            => _createCount(definition);
 
         /// <summary>
         /// Create a histogram metric
@@ -64,7 +64,7 @@ namespace Ubiquitous.Metrics {
         /// <param name="definition">Metric definition (name, description and labels)</param>
         /// <returns></returns>
         public IHistogramMetric CreateHistogram(MetricDefinition definition)
-            => Ensure.NotDefault(_createHistogram, "Metrics provider hasn't been configured")(definition);
+            => _createHistogram(definition);
 
         /// <summary>
         /// Create a gauge metric
@@ -72,7 +72,7 @@ namespace Ubiquitous.Metrics {
         /// <param name="definition">Metric definition (name, description and labels)</param>
         /// <returns></returns>
         public IGaugeMetric CreateGauge(MetricDefinition definition)
-            => Ensure.NotDefault(_createGauge, "Metrics provider hasn't been configured")(definition);
+            => _createGauge(definition);
 
         [Obsolete("Use MeasureTask")]
         public static Task Measure(

--- a/src/Ubiquitous.Metrics/Metrics.cs
+++ b/src/Ubiquitous.Metrics/Metrics.cs
@@ -17,7 +17,10 @@ namespace Ubiquitous.Metrics {
         Func<MetricDefinition, IGaugeMetric>?     _createGauge;
         Func<MetricDefinition, IHistogramMetric>? _createHistogram;
 
-        static Metrics() => Instance = new Metrics();
+        static Metrics() {
+            Instance = new Metrics();
+            Instance = CreateUsing(new NoMetricsProvider());
+        }
 
         /// <summary>
         /// Get the Metrics instance. Normally, you'd need only one Metrics instance per application.

--- a/test/Ubiquitous.Metrics.Tests/MetricsInstanceTests.cs
+++ b/test/Ubiquitous.Metrics.Tests/MetricsInstanceTests.cs
@@ -1,0 +1,27 @@
+using System;
+using FluentAssertions;
+using Xunit;
+
+namespace Ubiquitous.Metrics.Tests {
+    public class MetricsInstanceTests {
+        [Fact]
+        public void ShouldNotThrowIfMetricsNotConfigured() {
+            Action captureSomeMetrics = () => TestApplicationMetrics.CountUploads(Guid.NewGuid());
+
+            captureSomeMetrics.Should().NotThrow<Exception>();
+
+            TestApplicationMetrics.UploadsCounter.Should().Be(1);
+        }
+    }
+
+    static class TestApplicationMetrics {
+        static ICountMetric UploadsCount { get; } = Metrics.Instance.CreateCount("app_uploads", "Number of uploads", "request_id");
+
+        public static ulong UploadsCounter { get; private set; }
+
+        public static void CountUploads(Guid requestId) {
+            UploadsCount.Inc(new[] { requestId.ToString() });
+            UploadsCounter++;
+        }
+    }
+}

--- a/test/Ubiquitous.Metrics.Tests/Ubiquitous.Metrics.Tests.csproj
+++ b/test/Ubiquitous.Metrics.Tests/Ubiquitous.Metrics.Tests.csproj
@@ -1,23 +1,27 @@
-<Project>
+<Project Sdk="Microsoft.NET.Sdk">
+
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
+        <Nullable>enable</Nullable>
+
         <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoFixture" Version="4.17.0"/>
-        <PackageReference Include="Bogus" Version="33.0.2"/>
-        <PackageReference Include="FluentAssertions" Version="6.0.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0"/>
-        <PackageReference Include="xunit" Version="2.4.1"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+        <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="3.0.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
     </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Ubiquitous.Metrics\Ubiquitous.Metrics.csproj" />
+    </ItemGroup>
+
 </Project>


### PR DESCRIPTION
The default behaviour of the `Metrics.Instance` should allow its usage without any configuration.

The `NoMetricsProvider` is set by default, yet some validation is done after, forcing the user to still have to configure it anyway, defeating its purpose.

This PR fixes it by removing that validation.